### PR TITLE
Webp images implemented

### DIFF
--- a/packages/art/components/ArtistBanner.vue
+++ b/packages/art/components/ArtistBanner.vue
@@ -6,7 +6,7 @@
         <p class="whitespace-pre-wrap text-2">{{description}}</p>
       </div>
       <Image
-        :src="imageUrl"
+        :src="`${imageUrl}?fm=webp`"
         :alt="`Artist: ${name}`"
         fetch-priority="high"
       />

--- a/packages/art/components/GalleryPosters.vue
+++ b/packages/art/components/GalleryPosters.vue
@@ -17,7 +17,7 @@
         :class="{'slide-first': i === 0}"
     >
       <Image
-        :src="`${img.url}?w=${600}`"
+        :src="`${img.url}?w=${600}&fm=webp`"
         :alt="img.title"
         :class="{'image-frame': i === 0}"
         class="w-full h-full object-contain object-top"

--- a/packages/art/components/MasonryImage.vue
+++ b/packages/art/components/MasonryImage.vue
@@ -5,7 +5,7 @@
       class="mb-1 md:mb-2 px-2 md:px-3 py-3 bg-grey-30 flex items-center flex-1 -mx-1 sm:mx-0"
     >
       <Image
-        :src="`${url}?w=600`"
+        :src="`${url}?w=600&fm=webp`"
         :alt="`Surf Garage Art Co - ${title}`"
         class="min-h-[20rem] w-full bg-white image-frame border-[2rem] border-white"
         :fetch-priority="fetchPriority"

--- a/packages/art/components/MasonryPoster.vue
+++ b/packages/art/components/MasonryPoster.vue
@@ -5,7 +5,7 @@
       class="mb-1 md:mb-2 p-3 md:p-5 bg-grey-30 flex items-center flex-1 -mx-1 sm:mx-0"
     >
       <Image
-        :src="`${url}?w=600`"
+        :src="`${url}?w=600&fm=webp`"
         :alt="`Surf Garage Art Co - ${title}`"
         class="min-h-[20rem] w-full image-frame"
         :fetch-priority="fetchPriority"

--- a/packages/art/pages/prints/[id].vue
+++ b/packages/art/pages/prints/[id].vue
@@ -4,7 +4,7 @@
     <section class="bg-grey-30 mobile:-mx-1">
       <div class="px-2 py-3 md:px-5 md:py-6">
         <Image
-          :src="`${url}?w=700`"
+          :src="`${url}?w=700&fm=webp`"
           :alt="`Surf Garage - ${title}`"
           class="bg-white image-frame mx-auto border-[2rem] md:border-[3rem] border-white max-h-[70rem]"
           fetch-priority="high"

--- a/packages/boardStorage/components/Gallery.vue
+++ b/packages/boardStorage/components/Gallery.vue
@@ -10,7 +10,7 @@
         v-for="img in images"
         :key="img.id">
       <img
-          :src="`${img.url}?w=${width || 600}`"
+          :src="`${img.url}?w=${width || 600}&fm=webp`"
           alt="Gallery Image"
           :class="{'h-full object-cover' : fillHeight }"
           />

--- a/packages/boardStorage/components/blog/RichText.vue
+++ b/packages/boardStorage/components/blog/RichText.vue
@@ -3,7 +3,7 @@
     <template v-for="(item, i) in contentMap" :key="i">
       <BlogRichTextParagraph v-if="item.type == 'text'" class="mb-2 lg:mb-4 text-justify" :content="item.content"/>
       <BlogRichTextHeading v-if="item.type === 'heading'" class="mb-2" :format="item.format" :text="item.content"/>
-      <img v-if="item.type == 'image'" class="mb-2 lg:mb-4 mx-auto" :src="`${item.content}?w=600`" />
+      <img v-if="item.type == 'image'" class="mb-2 lg:mb-4 mx-auto" :src="`${item.content}?w=600&fm=webp`" />
       <video v-if="item.type == 'video'" class="mb-2 lg:mb-4 w-full max-w-[60rem] mx-auto" controls >
          <source :src="item.content" :type="item.format" />
       </video>

--- a/packages/boardStorage/components/boards/Tile.vue
+++ b/packages/boardStorage/components/boards/Tile.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <NuxtLink :to="localePath(`/${slug}`)" class="text-2 mb-2 block">
-      <img :src="`${image}?w=600`" class="mb-1" />
+      <img :src="`${image}?w=600&fm=webp`" class="mb-1" />
       <p class="font-avenir font-bold">{{title}}</p>
       <p class="font-avenir">€{{price}}</p>
     </NuxtLink>

--- a/packages/boardStorage/pages/boards/[...slug].vue
+++ b/packages/boardStorage/pages/boards/[...slug].vue
@@ -4,7 +4,7 @@
       <img
           v-for="{id, url} in images"
           :key="id"
-          :src="`${url}?w=600`"
+          :src="`${url}?w=600&fm=webp`"
           />
     </section>
     <section>


### PR DESCRIPTION
Without webp we had - 8.3mb initial load of HP without scroll and without cache/gzip
With webp we have - 7.8mb on homepage

On Artist-> Sam Garg we reduce almost 300kb only from your poster image, so performance should be a way better.

Transformation logic is simple enough and image type could be checked from here - 
![image](https://github.com/samgarg86/surf-garage-nuxt3/assets/7360345/b46100a4-a52a-48f0-8836-76f62b079d27)
